### PR TITLE
初期実装: 基本ゲームループと変異機能

### DIFF
--- a/content/config.json
+++ b/content/config.json
@@ -1,0 +1,31 @@
+{
+  "generators": [
+    {"id":"sprinkler","name":"スプリンクラー","baseCost":50,"r":1.15,"p0":0.5,"alpha":1.08},
+    {"id":"growlight","name":"育成灯","baseCost":250,"r":1.16,"p0":3,"alpha":1.09}
+  ],
+  "plants": [
+    {"id":"sprout","name":"ミニスプラウト","biome":"temperate","stages":[100,600,2500,12000,60000]},
+    {"id":"cactusling","name":"カクティ","biome":"desert","stages":[500,2500,15000,80000,400000]},
+    {"id":"waterfern","name":"ミズシダ","biome":"wetland","stages":[400,2000,12000,70000,350000]}
+  ],
+  "relics": [
+    {"id":"ancient_wateringcan","name":"古の如雨露","rarity":"rare","effects":[{"type":"click_mult","value":0.25}]},
+    {"id":"amber_pollen","name":"琥珀の花粉","rarity":"epic","effects":[{"type":"offline_cap_mult","value":0.2}]},
+    {"id":"solar_lattice","name":"ソーラー格子","rarity":"legendary","effects":[{"type":"day_bonus_mult","value":0.3}]},
+    {"id":"mist_bell","name":"霧の鈴","rarity":"rare","effects":[{"type":"autogen_mult","value":0.15}]}
+  ],
+  "seedPools": [
+    {"id":"temperate_basic","hint":"温帯","weights":{"common":70,"rare":25,"epic":4,"legendary":1},"candidates":["sprout","waterfern"]},
+    {"id":"desert_basic","hint":"砂漠","weights":{"common":70,"rare":25,"epic":4,"legendary":1},"candidates":["cactusling"]}
+  ],
+  "gacha": {
+    "rates": {"common":0.6,"rare":0.3,"epic":0.09,"legendary":0.01},
+    "softEpicStart": 40,
+    "hardLegendary": 120,
+    "tenShotRareGuarantee": true
+  },
+  "traits": [
+    {"id":"mut_bonus","name":"突然変異","effects":[{"type":"click_mult","value":0.1}]}
+  ],
+  "mutation": {"baseRate":0.05,"pity":10}
+}

--- a/dist/State.js
+++ b/dist/State.js
@@ -1,0 +1,49 @@
+export const defaultState = {
+    version: "1.1.0",
+    pe: 0,
+    generators: {},
+    plant: { id: "sprout", stage: 0, progress: 0 },
+    seeds: [],
+    dex: [],
+    dexVariants: [],
+    dust: 0,
+    relics: {},
+    pity: { seedNoNewCount: 0, pulls: 0, epicBonus: 0, mutationNoHit: 0 }
+};
+export function loadState() {
+    try {
+        const raw = localStorage.getItem('bq_save');
+        if (!raw)
+            return structuredClone(defaultState);
+        const data = JSON.parse(raw);
+        return migrateSave(data);
+    }
+    catch {
+        return structuredClone(defaultState);
+    }
+}
+export function saveState(state) {
+    localStorage.setItem('bq_save', JSON.stringify(state));
+}
+function migrateSave(data) {
+    if (!data.version)
+        return structuredClone(defaultState);
+    if (data.version === "1.0.0") {
+        const v1 = data;
+        const seeds = v1.seeds.map(s => ({ ...s, variant: false, traits: [], progress: s.progress }));
+        const save = {
+            version: "1.1.0",
+            pe: v1.pe,
+            generators: v1.generators,
+            plant: v1.plant,
+            seeds,
+            dex: v1.dex,
+            dexVariants: [],
+            dust: v1.dust,
+            relics: v1.relics,
+            pity: { ...v1.pity, mutationNoHit: 0 }
+        };
+        return save;
+    }
+    return data;
+}

--- a/dist/core/Economy.js
+++ b/dist/core/Economy.js
@@ -1,0 +1,38 @@
+import config from "../../content/config.json";
+export function cost(base, r, n) {
+    return Math.floor(base * Math.pow(r, n));
+}
+export function prod(p0, alpha, n) {
+    return p0 * Math.pow(n, alpha);
+}
+function getEffect(state, type) {
+    let sum = 0;
+    for (const id in state.relics) {
+        const info = state.relics[id];
+        const relic = config.relics.find(r => r.id === id);
+        if (!relic)
+            continue;
+        for (const e of relic.effects) {
+            if (e.type === type)
+                sum += e.value * info.stars;
+        }
+    }
+    return sum;
+}
+export function clickAmount(state) {
+    const base = 1;
+    let amt = base * (1 + getEffect(state, "click_mult"));
+    if (Math.random() < 0.05)
+        amt *= 5;
+    return amt;
+}
+export function autogenPerSec(state) {
+    let total = 0;
+    for (const g of config.generators) {
+        const n = state.generators[g.id] || 0;
+        if (n > 0)
+            total += prod(g.p0, g.alpha, n);
+    }
+    total *= (1 + getEffect(state, "autogen_mult"));
+    return total;
+}

--- a/dist/core/Gacha.js
+++ b/dist/core/Gacha.js
@@ -1,0 +1,45 @@
+import config from "../../content/config.json";
+function drawRarity(state, cfg) {
+    const pulls = state.pity.pulls + 1;
+    if (pulls >= cfg.hardLegendary) {
+        state.pity.pulls = 0;
+        return "legendary";
+    }
+    let rates = { ...cfg.rates };
+    const bonus = Math.max(0, Math.min(pulls - cfg.softEpicStart + 1, 20)) / 100;
+    state.pity.epicBonus = bonus * 100;
+    rates.epic += bonus;
+    rates.common -= bonus;
+    const guaranteeRare = cfg.tenShotRareGuarantee && pulls % 10 === 0;
+    let r = Math.random();
+    if (guaranteeRare) {
+        const total = rates.rare + rates.epic + rates.legendary;
+        r *= total;
+        if (r < rates.rare)
+            return "rare";
+        r -= rates.rare;
+        if (r < rates.epic)
+            return "epic";
+        return "legendary";
+    }
+    if (r < rates.common)
+        return "common";
+    r -= rates.common;
+    if (r < rates.rare)
+        return "rare";
+    r -= rates.rare;
+    if (r < rates.epic)
+        return "epic";
+    return "legendary";
+}
+export function rollGacha(state) {
+    const rarity = drawRarity(state, config.gacha);
+    state.pity.pulls++;
+    const pool = config.relics.filter(r => r.rarity === rarity);
+    const opts = [];
+    for (let i = 0; i < 3 && pool.length > 0; i++) {
+        const idx = Math.floor(Math.random() * pool.length);
+        opts.push(pool.splice(idx, 1)[0]);
+    }
+    return opts;
+}

--- a/dist/features.js
+++ b/dist/features.js
@@ -1,0 +1,6 @@
+export const FEATURES = {
+    OFFLINE: false,
+    FEVER: false,
+    DAILIES: false,
+    MUTATION: false
+};

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,101 @@
+import { loadState, saveState } from "./State";
+import config from "../content/config.json";
+import { autogenPerSec } from "./core/Economy";
+import { HomeView } from "./ui/HomeView";
+import { SeedsView } from "./ui/SeedsView";
+import { RelicsView } from "./ui/RelicsView";
+import { DexView } from "./ui/DexView";
+import { FEATURES } from "./features";
+const state = loadState();
+const home = new HomeView(state);
+const seeds = new SeedsView(state);
+const relics = new RelicsView(state);
+const dex = new DexView(state);
+const view = document.getElementById('view');
+function show(v) { view.innerHTML = ''; view.appendChild(v.el); v.render(); }
+document.getElementById('tab-home').onclick = () => show(home);
+document.getElementById('tab-seeds').onclick = () => show(seeds);
+document.getElementById('tab-relics').onclick = () => show(relics);
+document.getElementById('tab-dex').onclick = () => show(dex);
+show(home);
+const TICK_MS = 100;
+let acc = 0, last = performance.now();
+function loop(now) {
+    const dt = now - last;
+    last = now;
+    acc += dt;
+    while (acc >= TICK_MS) {
+        state.pe += autogenPerSec(state) * (TICK_MS / 1000);
+        advancePlant(state, TICK_MS);
+        advanceSeeds(state, TICK_MS);
+        acc -= TICK_MS;
+    }
+    home.render();
+    seeds.render();
+    relics.render();
+    dex.render();
+    saveState(state);
+    requestAnimationFrame(loop);
+}
+requestAnimationFrame(loop);
+function advancePlant(state, dt) {
+    const cfg = config.plants.find(p => p.id === state.plant.id);
+    state.plant.progress += dt;
+    if (state.plant.progress >= cfg.stages[state.plant.stage]) {
+        state.plant.progress = 0;
+        state.plant.stage++;
+        if (state.plant.stage >= 4) {
+            dropSeed(state);
+            state.plant.stage = 0;
+        }
+    }
+}
+function dropSeed(state) {
+    if (state.seeds.length >= 3)
+        return;
+    let chance = 0.6;
+    const unreg = 1 - state.dex.length / config.plants.length;
+    chance += 0.2 * unreg;
+    if (Math.random() > chance)
+        return;
+    const pool = config.seedPools[0];
+    const seed = { state: 'unknown', poolId: pool.id };
+    if (FEATURES.MUTATION) {
+        const mut = config.mutation;
+        const pity = state.pity.mutationNoHit;
+        let rate = mut.baseRate;
+        if (pity >= mut.pity)
+            rate = 1;
+        if (Math.random() < rate) {
+            seed.variant = true;
+            seed.traits = [config.traits[0].id];
+            state.pity.mutationNoHit = 0;
+        }
+        else
+            state.pity.mutationNoHit++;
+    }
+    state.seeds.push(seed);
+}
+function advanceSeeds(state, dt) {
+    for (const s of state.seeds) {
+        if (s.state === 'planted') {
+            const cfg = config.plants.find(p => p.id === s.plantId);
+            const need = cfg.stages[0] + cfg.stages[1];
+            s.progress = (s.progress || 0) + dt;
+            if ((s.progress || 0) >= need) {
+                s.state = 'revealed';
+                const newSp = !state.dex.includes(s.plantId);
+                if (newSp)
+                    state.dex.push(s.plantId);
+                else
+                    state.dust++;
+                if (s.variant) {
+                    if (!state.dexVariants.includes(s.plantId))
+                        state.dexVariants.push(s.plantId);
+                    else
+                        state.dust++;
+                }
+            }
+        }
+    }
+}

--- a/dist/ui/DexView.js
+++ b/dist/ui/DexView.js
@@ -1,0 +1,18 @@
+import config from "../../content/config.json";
+export class DexView {
+    constructor(state) {
+        this.state = state;
+        this.el = document.createElement('div');
+        this.render();
+    }
+    render() {
+        this.el.innerHTML = "";
+        for (const id of this.state.dex) {
+            const plant = config.plants.find(p => p.id === id);
+            const div = document.createElement('div');
+            const variant = this.state.dexVariants.includes(id);
+            div.innerHTML = `${plant.name}${variant ? '<span class="variant">Variant</span>' : ''}`;
+            this.el.appendChild(div);
+        }
+    }
+}

--- a/dist/ui/HomeView.js
+++ b/dist/ui/HomeView.js
@@ -1,0 +1,44 @@
+import { saveState } from "../State";
+import config from "../../content/config.json";
+import { clickAmount, cost, autogenPerSec } from "../core/Economy";
+export class HomeView {
+    constructor(state) {
+        this.state = state;
+        this.el = document.createElement('div');
+        this.render();
+    }
+    click() {
+        this.state.pe += clickAmount(this.state);
+        saveState(this.state);
+        this.render();
+    }
+    buy(id) {
+        const cfg = config.generators.find(g => g.id === id);
+        const n = this.state.generators[id] || 0;
+        const c = cost(cfg.baseCost, cfg.r, n);
+        if (this.state.pe >= c) {
+            this.state.pe -= c;
+            this.state.generators[id] = n + 1;
+            saveState(this.state);
+            this.render();
+        }
+    }
+    render() {
+        const peSec = autogenPerSec(this.state);
+        this.el.innerHTML = `<div>PE: ${Math.floor(this.state.pe)}</div>
+<button id="click">Tap</button>
+<div>PE/s: ${peSec.toFixed(2)}</div>
+<div id="gens"></div>`;
+        this.el.querySelector('#click').addEventListener('click', () => this.click());
+        const gens = this.el.querySelector('#gens');
+        for (const g of config.generators) {
+            const n = this.state.generators[g.id] || 0;
+            const c = cost(g.baseCost, g.r, n);
+            const prod = g.p0 * Math.pow(n + 1, g.alpha) - g.p0 * Math.pow(n, g.alpha);
+            const div = document.createElement('div');
+            div.innerHTML = `${g.name} x${n} cost:${c} prod:+${prod.toFixed(2)} <button>buy</button>`;
+            div.querySelector('button').addEventListener('click', () => this.buy(g.id));
+            gens.appendChild(div);
+        }
+    }
+}

--- a/dist/ui/RelicsView.js
+++ b/dist/ui/RelicsView.js
@@ -1,0 +1,43 @@
+import { saveState } from "../State";
+import { rollGacha } from "../core/Gacha";
+export class RelicsView {
+    constructor(state) {
+        this.state = state;
+        this.options = null;
+        this.el = document.createElement('div');
+        this.render();
+    }
+    gacha() {
+        const opts = rollGacha(this.state);
+        saveState(this.state);
+        this.options = document.createElement('div');
+        for (const r of opts) {
+            const div = document.createElement('div');
+            div.className = 'relic-option';
+            div.textContent = r.name;
+            div.onclick = () => { this.pick(r); };
+            this.options.appendChild(div);
+        }
+        this.render();
+    }
+    pick(r) {
+        const rec = this.state.relics[r.id];
+        if (rec) {
+            rec.stars = Math.min(5, rec.stars + 1);
+        }
+        else
+            this.state.relics[r.id] = { stars: 1 };
+        this.options = null;
+        saveState(this.state);
+        this.render();
+    }
+    render() {
+        this.el.innerHTML = `<div>pulls:${this.state.pity.pulls} epic+${this.state.pity.epicBonus}%</div>`;
+        const btn = document.createElement('button');
+        btn.textContent = 'ガチャ';
+        btn.onclick = () => this.gacha();
+        this.el.appendChild(btn);
+        if (this.options)
+            this.el.appendChild(this.options);
+    }
+}

--- a/dist/ui/SeedsView.js
+++ b/dist/ui/SeedsView.js
@@ -1,0 +1,55 @@
+import { saveState } from "../State";
+import config from "../../content/config.json";
+export class SeedsView {
+    constructor(state) {
+        this.state = state;
+        this.el = document.createElement('div');
+        this.render();
+    }
+    plant(i) {
+        const seed = this.state.seeds[i];
+        if (seed.state !== "unknown")
+            return;
+        const pool = config.seedPools.find(p => p.id === seed.poolId);
+        const plantId = pool.candidates[Math.floor(Math.random() * pool.candidates.length)];
+        seed.state = "planted";
+        seed.plantId = plantId;
+        seed.progress = 0;
+        saveState(this.state);
+        this.render();
+    }
+    collect(i) {
+        this.state.seeds.splice(i, 1);
+        saveState(this.state);
+        this.render();
+    }
+    render() {
+        this.el.innerHTML = "";
+        this.state.seeds.forEach((s, i) => {
+            const div = document.createElement('div');
+            div.className = 'seed';
+            if (s.state === 'unknown') {
+                div.textContent = `${s.poolId} 未鑑定`;
+                const b = document.createElement('button');
+                b.textContent = '植える';
+                b.onclick = () => this.plant(i);
+                div.appendChild(b);
+            }
+            else if (s.state === 'planted') {
+                const cfg = config.plants.find(p => p.id === s.plantId);
+                const need = cfg.stages[0] + cfg.stages[1];
+                const prog = Math.min(1, (s.progress || 0) / need);
+                div.textContent = `育成中 ${(prog * 100).toFixed(0)}%`;
+            }
+            else {
+                const cfg = config.plants.find(p => p.id === s.plantId);
+                div.innerHTML = `${cfg.name} ${s.variant ? '<span class="variant">Variant</span>' : ''}`;
+                const b = document.createElement('button');
+                b.textContent = '回収';
+                b.onclick = () => this.collect(i);
+                div.appendChild(b);
+            }
+            this.el.appendChild(div);
+        });
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8"/>
+<title>BloomQuest</title>
+<link rel="stylesheet" href="styles.css"/>
+</head>
+<body>
+<nav>
+  <button id="tab-home">Home</button>
+  <button id="tab-seeds">Seeds</button>
+  <button id="tab-relics">Relics</button>
+  <button id="tab-dex">Dex</button>
+</nav>
+<div id="view"></div>
+<script type="module" src="dist/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bloomquest",
+  "version": "0.1.0",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  }
+}

--- a/src/State.ts
+++ b/src/State.ts
@@ -1,0 +1,87 @@
+export interface SeedState {
+  state:"unknown"|"planted"|"revealed";
+  poolId:string;
+  plantId?:string;
+  progress?:number;
+  variant?:boolean;
+  traits?:string[];
+}
+
+export interface SaveV1 {
+  version:"1.0.0";
+  pe:number;
+  generators:Record<string,number>;
+  plant:{id:string;stage:number;progress:number};
+  seeds:SeedState[];
+  dex:string[];
+  dust:number;
+  relics:Record<string,{stars:number}>;
+  pity:{seedNoNewCount:number;pulls:number;epicBonus:number};
+}
+
+export interface SaveV1_1 {
+  version:"1.1.0";
+  pe:number;
+  generators:Record<string,number>;
+  plant:{id:string;stage:number;progress:number};
+  seeds:SeedState[];
+  dex:string[];
+  dexVariants:string[];
+  dust:number;
+  relics:Record<string,{stars:number}>;
+  pity:{seedNoNewCount:number;pulls:number;epicBonus:number;mutationNoHit:number};
+}
+
+export type Save = SaveV1_1;
+
+export const defaultState:Save = {
+  version:"1.1.0",
+  pe:0,
+  generators:{},
+  plant:{id:"sprout",stage:0,progress:0},
+  seeds:[],
+  dex:[],
+  dexVariants:[],
+  dust:0,
+  relics:{},
+  pity:{seedNoNewCount:0,pulls:0,epicBonus:0,mutationNoHit:0}
+};
+
+export type State = Save;
+
+export function loadState():State {
+  try {
+    const raw = localStorage.getItem('bq_save');
+    if (!raw) return structuredClone(defaultState);
+    const data = JSON.parse(raw);
+    return migrateSave(data);
+  } catch {
+    return structuredClone(defaultState);
+  }
+}
+
+export function saveState(state:State) {
+  localStorage.setItem('bq_save', JSON.stringify(state));
+}
+
+function migrateSave(data:any):State {
+  if (!data.version) return structuredClone(defaultState);
+  if (data.version === "1.0.0") {
+    const v1 = data as SaveV1;
+    const seeds = v1.seeds.map(s=>({ ...s, variant:false, traits:[], progress:s.progress }));
+    const save:Save = {
+      version:"1.1.0",
+      pe:v1.pe,
+      generators:v1.generators,
+      plant:v1.plant,
+      seeds,
+      dex:v1.dex,
+      dexVariants:[],
+      dust:v1.dust,
+      relics:v1.relics,
+      pity:{...v1.pity, mutationNoHit:0}
+    };
+    return save;
+  }
+  return data as Save;
+}

--- a/src/core/Economy.ts
+++ b/src/core/Economy.ts
@@ -1,0 +1,46 @@
+export interface GeneratorCfg { id:string; name:string; baseCost:number; r:number; p0:number; alpha:number; }
+export interface PlantCfg     { id:string; name:string; biome:string; stages:number[]; passive?:{type:string;value:number}; }
+export interface RelicCfg     { id:string; name:string; rarity:string; effects:{type:string;value:number}[]; set?:string; }
+export interface SeedPoolCfg  { id:string; hint:string; weights:Record<string,number>; candidates:string[]; }
+export interface GachaCfg     { rates:Record<string,number>; softEpicStart:number; hardLegendary:number; tenShotRareGuarantee:boolean; }
+
+import type { State } from "../State";
+import config from "../../content/config.json";
+
+export function cost(base:number, r:number, n:number):number {
+  return Math.floor(base * Math.pow(r, n));
+}
+
+export function prod(p0:number, alpha:number, n:number):number {
+  return p0 * Math.pow(n, alpha);
+}
+
+function getEffect(state:State, type:string):number {
+  let sum=0;
+  for (const id in state.relics) {
+    const info = state.relics[id];
+    const relic = config.relics.find(r=>r.id===id);
+    if (!relic) continue;
+    for (const e of relic.effects) {
+      if (e.type===type) sum += e.value * info.stars;
+    }
+  }
+  return sum;
+}
+
+export function clickAmount(state:State):number {
+  const base = 1;
+  let amt = base * (1 + getEffect(state, "click_mult"));
+  if (Math.random() < 0.05) amt *= 5;
+  return amt;
+}
+
+export function autogenPerSec(state:State):number {
+  let total=0;
+  for (const g of config.generators) {
+    const n = state.generators[g.id] || 0;
+    if (n>0) total += prod(g.p0, g.alpha, n);
+  }
+  total *= (1 + getEffect(state, "autogen_mult"));
+  return total;
+}

--- a/src/core/Gacha.ts
+++ b/src/core/Gacha.ts
@@ -1,0 +1,44 @@
+import config from "../../content/config.json";
+import { GachaCfg, RelicCfg } from "./Economy";
+import type { State } from "../State";
+
+function drawRarity(state:State, cfg:GachaCfg):string {
+  const pulls = state.pity.pulls + 1;
+  if (pulls >= cfg.hardLegendary) {
+    state.pity.pulls = 0;
+    return "legendary";
+  }
+  let rates = { ...cfg.rates } as Record<string,number>;
+  const bonus = Math.max(0, Math.min(pulls - cfg.softEpicStart + 1, 20)) / 100;
+  state.pity.epicBonus = bonus * 100;
+  rates.epic += bonus;
+  rates.common -= bonus;
+  const guaranteeRare = cfg.tenShotRareGuarantee && pulls % 10 === 0;
+  let r = Math.random();
+  if (guaranteeRare) {
+    const total = rates.rare + rates.epic + rates.legendary;
+    r *= total;
+    if (r < rates.rare) return "rare";
+    r -= rates.rare;
+    if (r < rates.epic) return "epic";
+    return "legendary";
+  }
+  if (r < rates.common) return "common";
+  r -= rates.common;
+  if (r < rates.rare) return "rare";
+  r -= rates.rare;
+  if (r < rates.epic) return "epic";
+  return "legendary";
+}
+
+export function rollGacha(state:State):RelicCfg[] {
+  const rarity = drawRarity(state, config.gacha);
+  state.pity.pulls++;
+  const pool = config.relics.filter(r=>r.rarity===rarity);
+  const opts:RelicCfg[] = [];
+  for (let i=0;i<3 && pool.length>0;i++) {
+    const idx = Math.floor(Math.random()*pool.length);
+    opts.push(pool.splice(idx,1)[0]);
+  }
+  return opts;
+}

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,0 +1,6 @@
+export const FEATURES = {
+  OFFLINE: false,
+  FEVER: false,
+  DAILIES: false,
+  MUTATION: false
+} as const;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,92 @@
+import { loadState, State, saveState, SeedState } from "./State";
+import config from "../content/config.json";
+import { autogenPerSec } from "./core/Economy";
+import { HomeView } from "./ui/HomeView";
+import { SeedsView } from "./ui/SeedsView";
+import { RelicsView } from "./ui/RelicsView";
+import { DexView } from "./ui/DexView";
+import { FEATURES } from "./features";
+
+const state = loadState();
+const home = new HomeView(state);
+const seeds = new SeedsView(state);
+const relics = new RelicsView(state);
+const dex = new DexView(state);
+const view = document.getElementById('view')!;
+
+function show(v:any){ view.innerHTML=''; view.appendChild(v.el); v.render(); }
+(document.getElementById('tab-home') as HTMLElement).onclick=()=>show(home);
+(document.getElementById('tab-seeds') as HTMLElement).onclick=()=>show(seeds);
+(document.getElementById('tab-relics') as HTMLElement).onclick=()=>show(relics);
+(document.getElementById('tab-dex') as HTMLElement).onclick=()=>show(dex);
+show(home);
+
+const TICK_MS=100;
+let acc=0,last=performance.now();
+function loop(now:number){
+  const dt=now-last; last=now; acc+=dt;
+  while(acc>=TICK_MS){
+    state.pe += autogenPerSec(state)*(TICK_MS/1000);
+    advancePlant(state,TICK_MS);
+    advanceSeeds(state,TICK_MS);
+    acc-=TICK_MS;
+  }
+  home.render(); seeds.render(); relics.render(); dex.render();
+  saveState(state);
+  requestAnimationFrame(loop);
+}
+requestAnimationFrame(loop);
+
+function advancePlant(state:State, dt:number){
+  const cfg=config.plants.find(p=>p.id===state.plant.id)!;
+  state.plant.progress += dt;
+  if(state.plant.progress >= cfg.stages[state.plant.stage]){
+    state.plant.progress=0;
+    state.plant.stage++;
+    if(state.plant.stage>=4){
+      dropSeed(state);
+      state.plant.stage=0;
+    }
+  }
+}
+
+function dropSeed(state:State){
+  if(state.seeds.length>=3) return;
+  let chance=0.6;
+  const unreg = 1 - state.dex.length / config.plants.length;
+  chance += 0.2*unreg;
+  if(Math.random()>chance) return;
+  const pool=config.seedPools[0];
+  const seed:SeedState={state:'unknown',poolId:pool.id};
+  if(FEATURES.MUTATION){
+    const mut=(config as any).mutation;
+    const pity=state.pity.mutationNoHit;
+    let rate=mut.baseRate;
+    if(pity>=mut.pity) rate=1;
+    if(Math.random()<rate){
+      seed.variant=true;
+      seed.traits=[(config as any).traits[0].id];
+      state.pity.mutationNoHit=0;
+    }else state.pity.mutationNoHit++;
+  }
+  state.seeds.push(seed);
+}
+
+function advanceSeeds(state:State, dt:number){
+  for(const s of state.seeds){
+    if(s.state==='planted'){
+      const cfg=config.plants.find(p=>p.id===s.plantId)!;
+      const need=cfg.stages[0]+cfg.stages[1];
+      s.progress=(s.progress||0)+dt;
+      if((s.progress||0)>=need){
+        s.state='revealed';
+        const newSp=!state.dex.includes(s.plantId!);
+        if(newSp) state.dex.push(s.plantId!); else state.dust++;
+        if(s.variant){
+          if(!state.dexVariants.includes(s.plantId!)) state.dexVariants.push(s.plantId!);
+          else state.dust++;
+        }
+      }
+    }
+  }
+}

--- a/src/ui/DexView.ts
+++ b/src/ui/DexView.ts
@@ -1,0 +1,20 @@
+import { State } from "../State";
+import config from "../../content/config.json";
+
+export class DexView {
+  el:HTMLElement;
+  constructor(private state:State){
+    this.el=document.createElement('div');
+    this.render();
+  }
+  render(){
+    this.el.innerHTML="";
+    for(const id of this.state.dex){
+      const plant=config.plants.find(p=>p.id===id)!;
+      const div=document.createElement('div');
+      const variant=this.state.dexVariants.includes(id);
+      div.innerHTML=`${plant.name}${variant?'<span class="variant">Variant</span>':''}`;
+      this.el.appendChild(div);
+    }
+  }
+}

--- a/src/ui/HomeView.ts
+++ b/src/ui/HomeView.ts
@@ -1,0 +1,45 @@
+import { State, saveState } from "../State";
+import config from "../../content/config.json";
+import { clickAmount, cost, autogenPerSec } from "../core/Economy";
+
+export class HomeView {
+  el:HTMLElement;
+  constructor(private state:State){
+    this.el=document.createElement('div');
+    this.render();
+  }
+  click(){
+    this.state.pe += clickAmount(this.state);
+    saveState(this.state);
+    this.render();
+  }
+  buy(id:string){
+    const cfg = config.generators.find(g=>g.id===id)!;
+    const n = this.state.generators[id]||0;
+    const c = cost(cfg.baseCost, cfg.r, n);
+    if (this.state.pe >= c){
+      this.state.pe -= c;
+      this.state.generators[id]=n+1;
+      saveState(this.state);
+      this.render();
+    }
+  }
+  render(){
+    const peSec = autogenPerSec(this.state);
+    this.el.innerHTML=`<div>PE: ${Math.floor(this.state.pe)}</div>
+<button id="click">Tap</button>
+<div>PE/s: ${peSec.toFixed(2)}</div>
+<div id="gens"></div>`;
+    this.el.querySelector('#click')!.addEventListener('click',()=>this.click());
+    const gens = this.el.querySelector('#gens') as HTMLElement;
+    for (const g of config.generators){
+      const n = this.state.generators[g.id]||0;
+      const c = cost(g.baseCost, g.r, n);
+      const prod = g.p0*Math.pow(n+1, g.alpha) - g.p0*Math.pow(n, g.alpha);
+      const div=document.createElement('div');
+      div.innerHTML=`${g.name} x${n} cost:${c} prod:+${prod.toFixed(2)} <button>buy</button>`;
+      div.querySelector('button')!.addEventListener('click',()=>this.buy(g.id));
+      gens.appendChild(div);
+    }
+  }
+}

--- a/src/ui/RelicsView.ts
+++ b/src/ui/RelicsView.ts
@@ -1,0 +1,39 @@
+import { State, saveState } from "../State";
+import config from "../../content/config.json";
+import { rollGacha } from "../core/Gacha";
+
+export class RelicsView {
+  el:HTMLElement;
+  options:HTMLElement|null=null;
+  constructor(private state:State){
+    this.el=document.createElement('div');
+    this.render();
+  }
+  gacha(){
+    const opts=rollGacha(this.state);
+    saveState(this.state);
+    this.options=document.createElement('div');
+    for(const r of opts){
+      const div=document.createElement('div');
+      div.className='relic-option';
+      div.textContent=r.name;
+      div.onclick=()=>{this.pick(r);};
+      this.options.appendChild(div);
+    }
+    this.render();
+  }
+  pick(r:any){
+    const rec=this.state.relics[r.id];
+    if(rec){ rec.stars=Math.min(5,rec.stars+1); }
+    else this.state.relics[r.id]={stars:1};
+    this.options=null;
+    saveState(this.state);
+    this.render();
+  }
+  render(){
+    this.el.innerHTML=`<div>pulls:${this.state.pity.pulls} epic+${this.state.pity.epicBonus}%</div>`;
+    const btn=document.createElement('button'); btn.textContent='ガチャ'; btn.onclick=()=>this.gacha();
+    this.el.appendChild(btn);
+    if(this.options) this.el.appendChild(this.options);
+  }
+}

--- a/src/ui/SeedsView.ts
+++ b/src/ui/SeedsView.ts
@@ -1,0 +1,47 @@
+import { State, saveState } from "../State";
+import config from "../../content/config.json";
+
+export class SeedsView {
+  el:HTMLElement;
+  constructor(private state:State){
+    this.el=document.createElement('div');
+    this.render();
+  }
+  plant(i:number){
+    const seed=this.state.seeds[i];
+    if(seed.state!=="unknown") return;
+    const pool=config.seedPools.find(p=>p.id===seed.poolId)!;
+    const plantId=pool.candidates[Math.floor(Math.random()*pool.candidates.length)];
+    seed.state="planted";
+    seed.plantId=plantId;
+    seed.progress=0;
+    saveState(this.state);
+    this.render();
+  }
+  collect(i:number){
+    this.state.seeds.splice(i,1);
+    saveState(this.state);
+    this.render();
+  }
+  render(){
+    this.el.innerHTML="";
+    this.state.seeds.forEach((s,i)=>{
+      const div=document.createElement('div');
+      div.className='seed';
+      if(s.state==='unknown'){
+        div.textContent=`${s.poolId} 未鑑定`;
+        const b=document.createElement('button'); b.textContent='植える'; b.onclick=()=>this.plant(i); div.appendChild(b);
+      }else if(s.state==='planted'){
+        const cfg=config.plants.find(p=>p.id===s.plantId)!;
+        const need=cfg.stages[0]+cfg.stages[1];
+        const prog=Math.min(1,(s.progress||0)/need);
+        div.textContent=`育成中 ${(prog*100).toFixed(0)}%`;
+      }else{
+        const cfg=config.plants.find(p=>p.id===s.plantId)!;
+        div.innerHTML=`${cfg.name} ${s.variant?'<span class="variant">Variant</span>':''}`;
+        const b=document.createElement('button'); b.textContent='回収'; b.onclick=()=>this.collect(i); div.appendChild(b);
+      }
+      this.el.appendChild(div);
+    });
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,6 @@
+body { font-family: sans-serif; }
+nav { margin-bottom: 10px; }
+#view { padding: 10px; }
+.seed { border: 1px solid #ccc; padding: 4px; margin: 4px; }
+.relic-option { border: 1px solid #999; margin: 4px; padding: 4px; cursor: pointer; }
+.variant { color: red; font-weight:bold; }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## 概要
- クリックや装置購入が可能なHomeタブを実装
- 種の植え付け・公開・図鑑登録と変異抽選機能を追加
- 遺物ガチャ(3択)と★強化、簡易天井処理を実装

## テスト
- `npm run build`
- `python -m http.server`（ポート確認コマンドが見つからず）

------
https://chatgpt.com/codex/tasks/task_e_68ac6cbc50e4832db35371abb0ba36d7