### PR TITLE
Fix JSON import for browser runtime

### DIFF
--- a/dist/core/Economy.js
+++ b/dist/core/Economy.js
@@ -1,4 +1,4 @@
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 export function cost(base, r, n) {
     return Math.floor(base * Math.pow(r, n));
 }

--- a/dist/core/Gacha.js
+++ b/dist/core/Gacha.js
@@ -1,4 +1,4 @@
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 function drawRarity(state, cfg) {
     const pulls = state.pity.pulls + 1;
     if (pulls >= cfg.hardLegendary) {

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,5 +1,5 @@
 import { loadState, saveState } from "./State";
-import config from "../content/config.json";
+import config from "../content/config.json" assert { type: "json" };
 import { autogenPerSec } from "./core/Economy";
 import { HomeView } from "./ui/HomeView";
 import { SeedsView } from "./ui/SeedsView";

--- a/dist/ui/DexView.js
+++ b/dist/ui/DexView.js
@@ -1,4 +1,4 @@
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 export class DexView {
     constructor(state) {
         this.state = state;

--- a/dist/ui/HomeView.js
+++ b/dist/ui/HomeView.js
@@ -1,5 +1,5 @@
 import { saveState } from "../State";
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 import { clickAmount, cost, autogenPerSec } from "../core/Economy";
 export class HomeView {
     constructor(state) {

--- a/dist/ui/SeedsView.js
+++ b/dist/ui/SeedsView.js
@@ -1,5 +1,5 @@
 import { saveState } from "../State";
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 export class SeedsView {
     constructor(state) {
         this.state = state;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "bloomquest",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bloomquest",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/src/core/Economy.ts
+++ b/src/core/Economy.ts
@@ -5,7 +5,7 @@ export interface SeedPoolCfg  { id:string; hint:string; weights:Record<string,nu
 export interface GachaCfg     { rates:Record<string,number>; softEpicStart:number; hardLegendary:number; tenShotRareGuarantee:boolean; }
 
 import type { State } from "../State";
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 
 export function cost(base:number, r:number, n:number):number {
   return Math.floor(base * Math.pow(r, n));

--- a/src/core/Gacha.ts
+++ b/src/core/Gacha.ts
@@ -1,4 +1,4 @@
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 import { GachaCfg, RelicCfg } from "./Economy";
 import type { State } from "../State";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { loadState, State, saveState, SeedState } from "./State";
-import config from "../content/config.json";
+import config from "../content/config.json" assert { type: "json" };
 import { autogenPerSec } from "./core/Economy";
 import { HomeView } from "./ui/HomeView";
 import { SeedsView } from "./ui/SeedsView";

--- a/src/ui/DexView.ts
+++ b/src/ui/DexView.ts
@@ -1,5 +1,5 @@
 import { State } from "../State";
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 
 export class DexView {
   el:HTMLElement;

--- a/src/ui/HomeView.ts
+++ b/src/ui/HomeView.ts
@@ -1,5 +1,5 @@
 import { State, saveState } from "../State";
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 import { clickAmount, cost, autogenPerSec } from "../core/Economy";
 
 export class HomeView {

--- a/src/ui/RelicsView.ts
+++ b/src/ui/RelicsView.ts
@@ -1,5 +1,5 @@
 import { State, saveState } from "../State";
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 import { rollGacha } from "../core/Gacha";
 
 export class RelicsView {

--- a/src/ui/SeedsView.ts
+++ b/src/ui/SeedsView.ts
@@ -1,5 +1,5 @@
 import { State, saveState } from "../State";
-import config from "../../content/config.json";
+import config from "../../content/config.json" assert { type: "json" };
 
 export class SeedsView {
   el:HTMLElement;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "ESNext",
     "moduleResolution": "node",
     "rootDir": "src",
     "outDir": "dist",


### PR DESCRIPTION
## Summary
- use `assert { type: "json" }` when importing configuration
- compile with ESNext modules to support JSON import assertions
- include package lock for repeatable installs

## Testing
- `npm install`
- `npm run build`
- `python -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68ac72884cf0832d81808dd937fb869f